### PR TITLE
chore: add codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,6 @@
+# More details are here: https://help.github.com/articles/about-codeowners/
+# The '*' pattern is global owners.
+# Order is important. The last matching pattern has the most precedence.
+
+/content/member/zzisu.md    @zzisu
+/content/member/skylee.md   @skylee03

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,5 +2,7 @@
 # The '*' pattern is global owners.
 # Order is important. The last matching pattern has the most precedence.
 
+*                           @swarmp/core
+
 /content/member/zzisu.md    @zzisu
 /content/member/skylee.md   @skylee03


### PR DESCRIPTION
Add codeowners to ensure modifications to `/content/member/*` must be reviewed by its owner